### PR TITLE
Make mongodb and location config options with default fallbacks

### DIFF
--- a/docs/Examples/mongo.js
+++ b/docs/Examples/mongo.js
@@ -6,6 +6,8 @@ const FullNode = bcoin.fullnode;
 const node = new FullNode({
   network: 'main',
   db: 'leveldb',
+  dbname: 'bcoin',
+  dburi: 'localhost',
   prefix: '.',
   checkpoints: true,
   workers: false,

--- a/docs/Examples/mongo.js
+++ b/docs/Examples/mongo.js
@@ -7,7 +7,7 @@ const node = new FullNode({
   network: 'main',
   db: 'leveldb',
   dbname: 'bcoin',
-  dburi: 'localhost',
+  dbhost: 'localhost',
   prefix: '.',
   checkpoints: true,
   workers: false,

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2384,7 +2384,7 @@ function ChainOptions(options) {
 
   this.prefix = null;
   this.dbname = null;
-  this.dburi = null;
+  this.dbhost = null;
   this.location = null;
   this.db = 'memory';
   this.maxFiles = 64;
@@ -2448,9 +2448,9 @@ ChainOptions.prototype.fromOptions = function fromOptions(options) {
     this.dbname = options.dbname;
   }
 
-  if (options.dburi != null) {
-    assert(typeof options.dburi === 'string');
-    this.dburi = options.dburi;
+  if (options.dbhost != null) {
+    assert(typeof options.dbhost === 'string');
+    this.dbhost = options.dbhost;
   }
 
   if (options.location != null) {

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2383,6 +2383,8 @@ function ChainOptions(options) {
   this.workers = null;
 
   this.prefix = null;
+  this.dbname = null;
+  this.dburi = null;
   this.location = null;
   this.db = 'memory';
   this.maxFiles = 64;
@@ -2439,6 +2441,16 @@ ChainOptions.prototype.fromOptions = function fromOptions(options) {
     this.location = this.spv
       ? path.join(this.prefix, 'spvchain')
       : path.join(this.prefix, 'chain');
+  }
+
+  if (options.dbname != null) {
+    assert(typeof options.dbname === 'string');
+    this.dbname = options.dbname;
+  }
+
+  if (options.dburi != null) {
+    assert(typeof options.dburi === 'string');
+    this.dburi = options.dburi;
   }
 
   if (options.location != null) {

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -11,9 +11,9 @@ function mongoDB(options) {
 
   console.log('Starting MongoDB...');
 
-  this.dburi = options.dburi;
+  this.dbhost = options.dbhost;
   this.dbname = options.dbname;
-  this.connectionString = `mongodb://${this.dburi}/${this.dbname}`;
+  this.connectionString = `mongodb://${this.dbhost}/${this.dbname}`;
 }
 
 mongoDB.prototype.open = async function () {

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -11,13 +11,15 @@ function mongoDB(options) {
 
   console.log('Starting MongoDB...');
 
-  // this.open();
+  this.dburi = options.dburi;
+  this.dbname = options.dbname;
+  this.connectionString = `mongodb://${this.dburi}/${this.dbname}`;
 }
 
 mongoDB.prototype.open = async function () {
   console.log('Opening MongoDB Connection');
 
-  return mongoose.connect('mongodb://localhost/bitcore');
+  return mongoose.connect(this.connectionString);
 };
 
 mongoDB.prototype.close = function() {

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -32,6 +32,9 @@ function Config(module) {
   this.prefix = Path.join(HOME, `.${module}`);
 
   this.options = Object.create(null);
+  this.options.dbname = 'bcoin',
+  this.options.dburi = 'localhost',
+
   this.data = Object.create(null);
   this.env = Object.create(null);
   this.args = Object.create(null);

--- a/lib/node/config.js
+++ b/lib/node/config.js
@@ -33,7 +33,7 @@ function Config(module) {
 
   this.options = Object.create(null);
   this.options.dbname = 'bcoin',
-  this.options.dburi = 'localhost',
+  this.options.dbhost = 'localhost',
 
   this.data = Object.create(null);
   this.env = Object.create(null);

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -53,7 +53,7 @@ function FullNode(options) {
     workers: this.workers,
     db: this.config.str('db'),
     dbname: this.config.str('dbname'),
-    dburi: this.config.str('dburi'),
+    dbhost: this.config.str('dbhost'),
     prefix: this.config.prefix,
     maxFiles: this.config.uint('max-files'),
     cacheSize: this.config.mb('cache-size'),

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -52,6 +52,8 @@ function FullNode(options) {
     logger: this.logger,
     workers: this.workers,
     db: this.config.str('db'),
+    dbname: this.config.str('dbname'),
+    dburi: this.config.str('dburi'),
     prefix: this.config.prefix,
     maxFiles: this.config.uint('max-files'),
     cacheSize: this.config.mb('cache-size'),


### PR DESCRIPTION
This refactors the mongodb location to configuration options and provides a default fallback to localhost/bcoin

Please test:
no db/location in node config
Changing db name
Changing db location
Stopping & Restarting sync
Stopping & Restarting sync moving between dbs
non-string values, etc

Running the mongo.js script in docs/Examples and changing its config values should be all you need 

@nitsujlangston @gasteve @sonicwizard
